### PR TITLE
Renamed restricted keyword parameter

### DIFF
--- a/src/producer/eosManager/transactionStateMachine.js
+++ b/src/producer/eosManager/transactionStateMachine.js
@@ -13,7 +13,7 @@ const VALID_STATE_TRANSITIONS = {
 module.exports = ({ logger, initialState = STATES.UNINITIALIZED }) => {
   let currentState = initialState
 
-  const guard = (object, method, { legalStates, async = true }) => {
+  const guard = (object, method, { legalStates, async: isAsync = true }) => {
     if (!object[method]) {
       throw new KafkaJSNonRetriableError(`Cannot add guard on missing method "${method}"`)
     }
@@ -26,7 +26,7 @@ module.exports = ({ logger, initialState = STATES.UNINITIALIZED }) => {
           `Transaction state exception: Cannot call "${method}" in state "${currentState}"`
         )
 
-        if (async) {
+        if (isAsync) {
           return Promise.reject(error)
         } else {
           throw error


### PR DESCRIPTION
Using a restricted keyword is considered bad practice and also causes an issue In [Terser](https://github.com/terser-js/terser):

```
ERROR in handlers/versions/activate-version.js from Terser
Unexpected token: operator (=) [./node_modules/kafkajs/src/producer/eosManager/transactionStateMachine.js:16,34][handlers/versions/activate-version.js:48083,54]
```